### PR TITLE
create a macro / run-operation to check if sources exist in a different database during a Slim CI check

### DIFF
--- a/dbt_snowflake/analysis/_information_schema.sql
+++ b/dbt_snowflake/analysis/_information_schema.sql
@@ -1,31 +1,29 @@
 -- this is an unused portion of onsemi/check_sources
 
 {% set sources=get_sources('raw') %}
+-- {{ sources }}
+-- {{ sources | length }}
 
-with
 
-information_schema_relations as (
-    select
-        table_catalog, -- Database that the table belongs to
-        table_schema, --Schema that the table belongs to
-        table_name, -- Name of the table
-        -- concat_ws('.', table_catalog, table_schema, table_name) as relation_name
-        concat_ws('.', table_schema, table_name) as relation_name
-    from raw.information_schema.tables 
-    -- where table_schema in ('jaffle_shop', 'stripe')
-)
-
-select * from information_schema_relations
-where 
--- table_schema ilike '{{ target.schema }}%'
--- and
- relation_name in
-    (
-        {%- for source in sources -%}
-            '{{ source.upper() }}'
-            {%- if not loop.last -%},{% endif %}
-        {%- endfor -%}
+    with
+    information_schema_relations as (
+        select
+            table_catalog, -- Database that the table belongs to
+            table_schema, --Schema that the table belongs to
+            table_name, -- Name of the table
+            concat_ws('.', table_catalog, table_schema, table_name) as fully_qualified_relation_name,
+            concat_ws('.', table_schema, table_name) as relation_name
+        from raw.information_schema.tables 
+        -- where table_schema in ('jaffle_shop', 'stripe')
     )
-
-
-
+    select * from information_schema_relations
+    where 
+    -- table_schema ilike '{{ target.schema }}%'
+    -- and
+    relation_name in
+        (
+            {%- for source in sources -%}
+                '{{ source.upper() }}'
+                {%- if not loop.last -%},{% endif %}
+            {%- endfor -%}
+        )

--- a/dbt_snowflake/macros/onsemi/check_against_information_schema.sql
+++ b/dbt_snowflake/macros/onsemi/check_against_information_schema.sql
@@ -11,7 +11,7 @@
         )
 
         {# get count of sources in target database #}
-        select count(*) from information_schema_relations   --todo remove +1
+        select count(*) from information_schema_relations
         where
         relation_name in
             (

--- a/dbt_snowflake/macros/onsemi/check_against_information_schema.sql
+++ b/dbt_snowflake/macros/onsemi/check_against_information_schema.sql
@@ -1,0 +1,80 @@
+{% macro check_against_information_schema(target_sources='raw', target_database='raw') %}
+    {% set sources=get_sources(target_sources) %}
+
+    {%- set information_schema_query %}
+        with
+        information_schema_relations as (
+            select
+                concat_ws('.', table_schema, table_name) as relation_name
+            from {{ target_database }}.information_schema.tables 
+            {# -- where table_schema ilike '{{ target_schema }}%' #}
+        )
+
+        {# get count of sources in target database #}
+        select count(*) from information_schema_relations   --todo remove +1
+        where
+        relation_name in
+            (
+                {%- for source in sources -%}
+                    '{{ source.upper() }}'
+                    {%- if not loop.last -%},{% endif %}
+                {%- endfor -%}
+            )
+    {% endset %}
+
+    {%- set results = run_query(information_schema_query) %}
+
+    {% if execute %}
+        {% set information_schema_count = results.columns[0].values()[0] %}
+    {% else %}
+        {% set information_schema_count = [] %}
+    {% endif %}
+
+{# If the count of current sources matches count in target database, check passes #}
+    {% if sources|length == information_schema_count %}
+        {{ log("Test passed: Found " ~ sources|length ~ " sources from the `" ~ target_sources ~ "` database and " ~ information_schema_count ~ " matching sources in the `" ~ target_database ~ "` database", info=True) }}
+
+    {% else %}
+{# If the count of sources does not match in both databases, check fails #}
+        {%- set find_missing_sources_query %}
+            with
+            information_schema_relations as (
+                select
+                    concat_ws('.', table_schema, table_name) as relation_name
+                from {{ target_database }}.information_schema.tables 
+                {# -- where table_schema ilike '{{ target_schema }}%' #}
+            )
+            select relation_name from information_schema_relations
+            where
+            relation_name in
+                (
+                    {%- for source in sources -%}
+                        '{{ source.upper() }}'
+                        {%- if not loop.last -%},{% endif %}
+                    {%- endfor -%}
+                )
+        {% endset %}
+
+        {%- set results = run_query(find_missing_sources_query) %}
+
+        {% if execute %}
+            {% set found_sources = results.columns[0].values() %}
+
+        {# check if current sources are found within target sources, if not, list them #}
+        {% set missing_sources=[] %}
+        {%- for source in sources -%}
+            {% if source.upper() not in found_sources %}
+                {% do missing_sources.append(source) %}
+            {% endif %}
+        {%- endfor -%}
+
+        {{ log("Test FAILED: Missing sources in target environment: " ~ missing_sources , info=True) }}
+        {{ missing_sources }}
+        
+        {{ exceptions.raise_compiler_error("Sources in `" ~ target_sources ~ "` database do not exist in the `" ~ target_database ~ "` database.") if execute }}
+        {% else %}
+            {{ log("Test FAILED", info=True) }}
+        {% endif %}
+
+    {% endif %}
+{% endmacro %}


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
* "Update: dbt version 0.13.0"
-->

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->
This is a continuation of https://github.com/patkearns10/dbt_workspace/pull/32, but rather than running as a model, run as a run-operation command in a job.

### fail with multiple missing
![Screen Shot 2022-11-17 at 4 35 56 PM](https://user-images.githubusercontent.com/30663534/202367830-5f8ec99c-e8af-44ca-863f-96d827a14e91.png)

### fail with one missing
![Screen Shot 2022-11-17 at 4 36 42 PM](https://user-images.githubusercontent.com/30663534/202367846-95ba3139-34e6-4312-a137-92cc8929fd4d.png)

### success
![Screen Shot 2022-11-17 at 4 42 44 PM](https://user-images.githubusercontent.com/30663534/202367871-16a9c1f7-3fe5-4846-8ce9-059702738024.png)

### fail using arguments (example command syntax)
`dbt run-operation check_against_information_schema --args '{target_database: analytics}'`
![Screen Shot 2022-11-17 at 4 51 37 PM](https://user-images.githubusercontent.com/30663534/202367927-1fbacf26-942a-4fb5-8504-536ba42126bd.png)

