### PR TITLE
hardcoded test exceptions from csv seed

### DIFF
--- a/dbt_snowflake/models/marts/core/__models.yml
+++ b/dbt_snowflake/models/marts/core/__models.yml
@@ -69,3 +69,12 @@ models:
         description: A boolean indicating if this order included any food items.
       - name: is_drink_order
         description: A boolean indicating if this order included any drink items.
+
+  - name: order_items
+    description: Order items overview data mart, offering key details for each order item inlcluding PRODUCT_ID, PRODUCT_PRICE, SUPPLY_COST. One row per order item.
+    columns:
+      - name: order_item_id
+        description: The unique key of the orders items mart.
+        tests:
+          - not_null
+          - unique_coded_exceptions

--- a/dbt_snowflake/models/marts/core/order_items.sql
+++ b/dbt_snowflake/models/marts/core/order_items.sql
@@ -55,3 +55,8 @@ joined as (
 )
 
 select * from joined
+
+-- creating a dupe
+-- this will fail a normal unique test
+union all
+select * from joined where order_item_id = '3f8b6d6a-c77a-46eb-8eb0-48f80acb9708'

--- a/dbt_snowflake/seeds/seed__coded_test_exceptions.csv
+++ b/dbt_snowflake/seeds/seed__coded_test_exceptions.csv
@@ -1,0 +1,4 @@
+model_name,column_name,test_name,filter_clause,description,valid_from,valid_to
+order_items,order_item_id,unique_coded_exceptions_order_items_order_item_id,order_item_id != '3f8b6d6a-c77a-46eb-8eb0-48f80acb9708',remove this id from test because dupes,'2024-04-16','2999-01-01'
+order_items,order_item_id,unique_coded_exceptions_order_items_order_item_id,order_item_id != 'test_item',test for multiple entries,'2024-04-16','2999-01-01'
+not_a_model,not_a_column,not_a_test,"1=1",test for not bringing in different model/test exceptions,'2024-04-16','2999-01-01'

--- a/dbt_snowflake/tests/generic/test__unique_coded_exceptions.sql
+++ b/dbt_snowflake/tests/generic/test__unique_coded_exceptions.sql
@@ -1,0 +1,30 @@
+{% test unique_coded_exceptions(model, column_name) %}
+
+{# get filter clause exceptions from seed__coded_test_exceptions #}
+{%- set get_column_values_filter %}
+    model_name = '{{ model.identifier }}' and column_name = '{{ column_name }}'
+{%- endset %}
+
+{%- set where_filters = dbt_utils.get_column_values(
+    table=ref('seed__coded_test_exceptions'),
+    column='filter_clause',
+    where=get_column_values_filter,
+    default=["1=1"]
+) -%}
+
+select
+    {{ column_name }} as unique_field,
+    count(*) as n_records
+from {{ model }}
+where {{ column_name }} is not null
+
+-- add exceptions filters from csv
+--------------------------------
+{% for where_filter in where_filters -%}
+    and {{ where_filter }}
+{% endfor -%}
+--------------------------------
+group by {{ column_name }}
+having count(*) > 1
+
+{% endtest %}


### PR DESCRIPTION
Use a csv to add coded test exceptions and pull from that csv into the where clause of a custom generic test:
https://www.loom.com/share/13dac2d5454b41b7830b5af9625a5190?sid=8ea4610d-bd6a-4dc1-a97a-50f86a26bc88