### PR TITLE
macro and example

### DIFF
--- a/dbt_snowflake/analysis/decoded.sql
+++ b/dbt_snowflake/analysis/decoded.sql
@@ -1,0 +1,104 @@
+{%- set join_conditions = [
+    {
+        "orig_column": "settlement_method_code",
+        "new_column": "settlement_method_decoded_eq",
+        "tag_name": "EQOPT_SETTLE",
+        "derived": true
+    },
+    {
+        "orig_column": "settlement_method_code",
+        "new_column": "settlement_method_decoded_opt",
+        "tag_name": "OPT_FUT_SETTLE",
+        "derived": true
+    },
+    {
+        "orig_column": "future_code",
+        "new_column": "future_code_decoded",
+        "tag_name": "FUTURE_TYPES"
+    },
+    {
+        "orig_column": "date_conv_code",
+        "new_column": "date_conv_decoded",
+        "tag_name": "DAY_COUNTS"
+    },
+    {
+        "orig_column": "option_call_put_code",
+        "new_column": "option_call_put_decoded1",
+        "tag_name": "CALL_OR_PUT",
+        "derived": true
+    },
+    {
+        "orig_column": "option_call_put_code",
+        "new_column": "option_call_put_decoded2",
+        "tag_name": "PC_TYPES",
+        "derived": true
+    },
+    {
+        "orig_column": "expiry_time_code",
+        "new_column": "expiry_time_decoded",
+        "tag_name": "OPTION_EXP_TIME",
+        "derived": true
+    },
+    {
+        "orig_column": "settlement_location_code",
+        "new_column": "settlement_location_decoded1",
+        "tag_name": "SETTLE_METHOD",
+        "derived": true
+    },
+    {
+        "orig_column": "settlement_location_code",
+        "new_column": "settlement_location_decoded2",
+        "tag_name": "SETTLE_LOC",
+        "derived": true
+    },
+    {
+        "orig_column": "desc_inst",
+        "new_column": "desc_inst_tpr",
+        "tag_name": "TPR_COLL_TYPES",
+        "derived": true
+    },
+    {
+        "orig_column": "desc_inst",
+        "new_column": "desc_inst_corp",
+        "tag_name": "CORP_CLASSES",
+        "derived": true
+    },
+    {
+        "orig_column": "desc_inst",
+        "new_column": "desc_inst_bndlocal",
+        "tag_name": "BNDLOCAL_CLASS",
+        "derived": true
+    },
+    {
+        "orig_column": "desc_inst",
+        "new_column": "desc_inst_cp",
+        "tag_name": "CP_CLASSES",
+        "derived": true
+    },
+    {
+        "orig_column": "desc_inst",
+        "new_column": "desc_inst_sm",
+        "tag_name": "SM_CT_CLASS",
+        "derived": true
+    },
+    {
+        "orig_column": "desc_inst",
+        "new_column": "desc_inst_tfn",
+        "tag_name": "TFN_CLASSES",
+        "derived": true
+    },
+    {
+        "orig_column": "desc_inst",
+        "new_column": "desc_inst_fund",
+        "tag_name": "FUND_TYPE",
+        "derived": true
+    },
+    {
+        "orig_column": "payment_convention_code",
+        "new_column": "payment_convention_decoded",
+        "tag_name": "ADJUST_METH",
+        "derived": true
+    }
+] %}
+
+{{ auto_decode(decode_ref=ref('dim_customers'), decode_ref_alias='customers', join_conditions=join_conditions)}}

--- a/dbt_snowflake/macros/auto_decode.sql
+++ b/dbt_snowflake/macros/auto_decode.sql
@@ -1,0 +1,62 @@
+{% macro auto_decode(decode_ref, decode_ref_alias, join_conditions=[]) -%}
+
+    {% set sql %}
+    with
+
+    decodes as (
+        select *
+        from {{ ref('fct_orders') }}
+    ),
+    
+    {{ decode_ref_alias }}_automatically_decoded as (
+        select
+            {{ decode_ref_alias }}.*,
+    
+            {%- for join in join_conditions %}
+            {%- if join.get('derived', false) %}
+            {{ join['new_column'] + "_decode" }}.value as {{ join['new_column'] }},
+            {%- else %}
+            coalesce({{ join['new_column'] + "_decode" }}.value, {{ join['orig_column'] }}) as {{ join['new_column'] }},
+            {%- endif %}
+            {%- endfor %}
+    
+            -- Create an array of all failed decodes for non-derived attributes.
+            array(
+                select obj from (
+                    {%- for join in join_conditions %}
+                    {%- if not join.get('derived', false) %} -- Derived decode fails need to be handled separately in the decodefails model.
+                    select
+                        if({{ join['new_column'] + "_decode" }}.value is null and {{ join['orig_column'] }} is not null,
+                            json_object('field', '{{ join['new_column'] }}',
+                                    'original_value', {{ join['orig_column'] }},
+                                    'tag_name', '{{ join['tag_name'] }}'),
+                            null) as obj
+                    {%- if not loop.last %} union all {% endif %}
+                    {%- endif %}
+                    {%- endfor %}
+                )
+                where obj is not null
+            ) as failed_decodes_nonderived
+    
+        from {{ decode_ref }} as {{ decode_ref_alias }}
+    
+        {%- for join in join_conditions %}
+        left join decodes as {{ join['new_column'] + "_decode" }}
+        {%- if join.get('case_insensitive', false) %}
+            on lower({{ decode_ref_alias }}.{{ join['orig_column'] }}) = lower({{ join['new_column'] + "_decode" }}.code)
+        {%- else %}
+            on {{ decode_ref_alias }}.{{ join['orig_column'] }} = {{ join['new_column'] + "_decode" }}.code
+        {%- endif %}
+            and {{ join['new_column'] + "_decode" }}.tag_name = '{{ join['tag_name'] }}'
+        {%- endfor %}
+    )
+    
+    select *
+    from {{ decode_ref_alias }}_automatically_decoded
+
+
+    {% endset %}
+
+    {{ return(sql) }}
+
+{%- endmacro %}

--- a/dbt_snowflake/macros/auto_decode.sql
+++ b/dbt_snowflake/macros/auto_decode.sql
@@ -5,7 +5,7 @@
 
     decodes as (
         select *
-        from {{ ref('fct_orders') }}
+        from {{ ref('int_decodes_security') }}
     ),
     
     {{ decode_ref_alias }}_automatically_decoded as (

--- a/dbt_snowflake/models/_core.yml
+++ b/dbt_snowflake/models/_core.yml
@@ -33,8 +33,3 @@ models:
       - a_plus_b_equals_c:
           model_a: ref('foo_table')
           model_b: ref('bar_table')
-  - name: union_relations
-    tests:
-      - a_plus_b_equals_c:
-          model_a: ref('foo_table')
-          model_b: ref('bar_table')


### PR DESCRIPTION
`analysis/decoded.sql`
has the example of how to call it. 
provide the join conditions, then call the macro with the ref / alias / join_conditions

output:
```



    with

    decodes as (
        select *
        from DEVELOPMENT.dbt_pkearns.int_decodes_security
    ),
    
    customers_automatically_decoded as (
        select
            customers.*,
            settlement_method_decoded_eq_decode.value as settlement_method_decoded_eq,
            settlement_method_decoded_opt_decode.value as settlement_method_decoded_opt,
            coalesce(future_code_decoded_decode.value, future_code) as future_code_decoded,
            coalesce(date_conv_decoded_decode.value, date_conv_code) as date_conv_decoded,
            option_call_put_decoded1_decode.value as option_call_put_decoded1,
            option_call_put_decoded2_decode.value as option_call_put_decoded2,
            expiry_time_decoded_decode.value as expiry_time_decoded,
            settlement_location_decoded1_decode.value as settlement_location_decoded1,
            settlement_location_decoded2_decode.value as settlement_location_decoded2,
            desc_inst_tpr_decode.value as desc_inst_tpr,
            desc_inst_corp_decode.value as desc_inst_corp,
            desc_inst_bndlocal_decode.value as desc_inst_bndlocal,
            desc_inst_cp_decode.value as desc_inst_cp,
            desc_inst_sm_decode.value as desc_inst_sm,
            desc_inst_tfn_decode.value as desc_inst_tfn,
            desc_inst_fund_decode.value as desc_inst_fund,
            payment_convention_decoded_decode.value as payment_convention_decoded,
    
            -- Create an array of all failed decodes for non-derived attributes.
            array(
                select obj from ( -- Derived decode fails need to be handled separately in the decodefails model.
                    select
                        if(future_code_decoded_decode.value is null and future_code is not null,
                            json_object('field', 'future_code_decoded',
                                    'original_value', future_code,
                                    'tag_name', 'FUTURE_TYPES'),
                            null) as obj union all  -- Derived decode fails need to be handled separately in the decodefails model.
                    select
                        if(date_conv_decoded_decode.value is null and date_conv_code is not null,
                            json_object('field', 'date_conv_decoded',
                                    'original_value', date_conv_code,
                                    'tag_name', 'DAY_COUNTS'),
                            null) as obj union all 
                )
                where obj is not null
            ) as failed_decodes_nonderived
    
        from DEVELOPMENT.dbt_pkearns.dim_customers as customers
        left join decodes as settlement_method_decoded_eq_decode
            on customers.settlement_method_code = settlement_method_decoded_eq_decode.code
            and settlement_method_decoded_eq_decode.tag_name = 'EQOPT_SETTLE'
        left join decodes as settlement_method_decoded_opt_decode
            on customers.settlement_method_code = settlement_method_decoded_opt_decode.code
            and settlement_method_decoded_opt_decode.tag_name = 'OPT_FUT_SETTLE'
        left join decodes as future_code_decoded_decode
            on customers.future_code = future_code_decoded_decode.code
            and future_code_decoded_decode.tag_name = 'FUTURE_TYPES'
        left join decodes as date_conv_decoded_decode
            on customers.date_conv_code = date_conv_decoded_decode.code
            and date_conv_decoded_decode.tag_name = 'DAY_COUNTS'
        left join decodes as option_call_put_decoded1_decode
            on customers.option_call_put_code = option_call_put_decoded1_decode.code
            and option_call_put_decoded1_decode.tag_name = 'CALL_OR_PUT'
        left join decodes as option_call_put_decoded2_decode
            on customers.option_call_put_code = option_call_put_decoded2_decode.code
            and option_call_put_decoded2_decode.tag_name = 'PC_TYPES'
        left join decodes as expiry_time_decoded_decode
            on customers.expiry_time_code = expiry_time_decoded_decode.code
            and expiry_time_decoded_decode.tag_name = 'OPTION_EXP_TIME'
        left join decodes as settlement_location_decoded1_decode
            on customers.settlement_location_code = settlement_location_decoded1_decode.code
            and settlement_location_decoded1_decode.tag_name = 'SETTLE_METHOD'
        left join decodes as settlement_location_decoded2_decode
            on customers.settlement_location_code = settlement_location_decoded2_decode.code
            and settlement_location_decoded2_decode.tag_name = 'SETTLE_LOC'
        left join decodes as desc_inst_tpr_decode
            on customers.desc_inst = desc_inst_tpr_decode.code
            and desc_inst_tpr_decode.tag_name = 'TPR_COLL_TYPES'
        left join decodes as desc_inst_corp_decode
            on customers.desc_inst = desc_inst_corp_decode.code
            and desc_inst_corp_decode.tag_name = 'CORP_CLASSES'
        left join decodes as desc_inst_bndlocal_decode
            on customers.desc_inst = desc_inst_bndlocal_decode.code
            and desc_inst_bndlocal_decode.tag_name = 'BNDLOCAL_CLASS'
        left join decodes as desc_inst_cp_decode
            on customers.desc_inst = desc_inst_cp_decode.code
            and desc_inst_cp_decode.tag_name = 'CP_CLASSES'
        left join decodes as desc_inst_sm_decode
            on customers.desc_inst = desc_inst_sm_decode.code
            and desc_inst_sm_decode.tag_name = 'SM_CT_CLASS'
        left join decodes as desc_inst_tfn_decode
            on customers.desc_inst = desc_inst_tfn_decode.code
            and desc_inst_tfn_decode.tag_name = 'TFN_CLASSES'
        left join decodes as desc_inst_fund_decode
            on customers.desc_inst = desc_inst_fund_decode.code
            and desc_inst_fund_decode.tag_name = 'FUND_TYPE'
        left join decodes as payment_convention_decoded_decode
            on customers.payment_convention_code = payment_convention_decoded_decode.code
            and payment_convention_decoded_decode.tag_name = 'ADJUST_METH'
    )
    
    select *
    from customers_automatically_decoded


    
```