### PR TITLE
safe_cast to string

### DIFF
--- a/dbt_bigquery/macros/log_dq_detail.sql
+++ b/dbt_bigquery/macros/log_dq_detail.sql
@@ -17,12 +17,16 @@
             {% set rule_id = value.database_name ~ '.' ~ value.table_name ~ '.' ~ result.column_name ~ '.' ~ result.test_name %}
             {% set result_detail_id = result.invocation_id ~ '.' ~ result.unique_id %}
             {% for error in result.failed_rows %}
+                {% set safe_error = {} %}
+                {% for k, v in error.items() %}
+                    {% do safe_error.update({k: v|string}) %}
+                {% endfor %}
                 {% set parsed_dq_detail_dict = {
                     'result_detail_id': result_detail_id,
                     'rule_sum_id': result.rule_sum_id,
                     'rule_id': rule_id,
-                    'error_record': tojson(error)
-                }%}
+                    'error_record': tojson(safe_error)
+                } %}
                 {% do parsed_dq_detail_list.append(parsed_dq_detail_dict) %}
             {% endfor %}
         {% endfor %}


### PR DESCRIPTION
error is a Python dict-like object coming from row.dict() in your parse_test_results macro.

If that row has values of type datetime.date, datetime.datetime, or decimal.Decimal, Jinja’s tojson can’t serialize them by default, so you get the error when a test failure row includes a DATE column.

Let's just cast them all to strings. 