### PR TITLE
Add xref() macro to dbt_snowflake_downstream for env-aware cross-project refs

### DIFF
--- a/dbt_snowflake_downstream/macros/macros.yml
+++ b/dbt_snowflake_downstream/macros/macros.yml
@@ -1,0 +1,29 @@
+version: 2
+
+macros:
+  - name: xref
+    description: >
+      Environment-aware drop-in replacement for cross-project ref(). When the
+      `xref_upstream_env` var/env var is unset, behaves identically to ref().
+      When set (e.g. to `prod`), rewrites the resolved relation's
+      database/schema to the upstream environment configured in
+      `xref_env_map`, and — if the referenced model is listed in
+      `xref_exposed_models` — swaps in the identifier of the
+      exposed/published view variant instead of the underlying table. Built
+      for multi-pre-prod setups where a non-prod environment (e.g. staging)
+      needs to deliberately read production-quality data from an upstream
+      project instead of that project's own staging environment.
+    arguments:
+      - name: package_name
+        type: string
+        description: >
+          The upstream project name to reference, matching ref()'s first
+          positional argument for a cross-project ref. If only one positional
+          argument is passed to xref(), it is treated as `model_name` and this
+          behaves as a normal same-project ref().
+      - name: model_name
+        type: string
+        description: The name of the model to reference.
+      - name: version
+        type: string
+        description: Optional model version, passed straight through to ref().

--- a/dbt_snowflake_downstream/macros/xref.sql
+++ b/dbt_snowflake_downstream/macros/xref.sql
@@ -1,0 +1,102 @@
+{% macro xref(package_name, model_name=none, version=none) %}
+{#-
+    xref() — environment-aware cross-project ref for multi-pre-prod setups.
+
+    Problem this solves (Macquarie demo):
+      dbt's native cross-project ref() always resolves an upstream PUBLIC model
+      to that upstream project's PRODUCTION relation, regardless of which
+      environment the downstream project is running in. Some orgs run several
+      long-lived pre-prod environments (dev/qa/uat/staging) that mirror each
+      other 1:1 upstream <-> downstream, and want staging-downstream to read
+      from staging-upstream, qa-downstream from qa-upstream, etc. — OR, as a
+      deliberate exception, want a specific non-prod environment (e.g. staging)
+      to read from the *prod* upstream because only prod has trustworthy data.
+
+    How it works:
+      1. If called with a single arg, behaves exactly like ref(model_name) —
+         no cross-project ref involved, nothing to override.
+      2. If called with (package_name, model_name), it first resolves the
+         relation the normal way via builtins.ref(), then — only when the
+         `xref_upstream_env` var/env var is explicitly set — rewrites the
+         database/schema of that relation to point at the requested upstream
+         environment, using a lookup table (`xref_env_map`) rather than any
+         hardcoded string-slicing logic. This keeps the redirect opt-in per
+         target (e.g. only turn it on for the `staging` job) and keeps the
+         env -> database/schema mapping explicit and easy to audit.
+      3. Optionally also swaps which *identifier* is read. Macquarie's second
+         requirement is that some upstream prod models are explicitly
+         published for consumption outside of prod as a `view` (e.g. masked /
+         filtered), while prod itself keeps reading the underlying `table`.
+         Rather than hardcoding a tag vs. prefix convention, this macro takes
+         an explicit map (`xref_exposed_models`) from "package.model" to the
+         identifier that should be substituted for non-prod consumers. This
+         works whether the upstream team's convention is a tag, a naming
+         prefix (e.g. `vw_orders`), or anything else — the map is the single
+         source of truth and is easy to point at either convention.
+
+    Vars (set in dbt_project.yml, or via --vars / env_var per job/target):
+
+      xref_upstream_env:
+        The upstream environment this run should read from, e.g. 'prod'.
+        Leave unset (default '') to fall back to normal dbt Mesh behavior
+        (always prod, no rewrite) — this makes xref() a safe drop-in
+        replacement for ref() everywhere else.
+        Example: --vars '{"xref_upstream_env": "prod"}'
+        or in dbt_project.yml under a target-specific block, or
+        env_var('DBT_XREF_UPSTREAM_ENV').
+
+      xref_env_map:
+        Dict mapping an upstream env name to the database/schema to redirect
+        to, e.g.:
+          xref_env_map:
+            prod:
+              database: ANALYTICS_PROD
+              # schema: (optional — omit to keep the schema ref() resolved)
+
+      xref_exposed_models:
+        Dict mapping "package_name.model_name" -> the identifier (table/view
+        name) that should be substituted when redirecting, e.g.:
+          xref_exposed_models:
+            secret.orders: vw_orders_prod_exposed
+
+    Usage: identical to ref() — {{ xref('secret', 'orders') }} or
+    {{ xref('my_model') }} for a same-project ref.
+-#}
+
+{%- if model_name is none -%}
+    {%- set model_name = package_name -%}
+    {%- set package_name = none -%}
+{%- endif -%}
+
+{%- if package_name is none -%}
+    {#- Same-project ref: no cross-project behavior to override -#}
+    {{ return(builtins.ref(model_name, version=version)) }}
+{%- endif -%}
+
+{%- set rel = builtins.ref(package_name, model_name, version=version) -%}
+
+{%- set upstream_env = var('xref_upstream_env', env_var('DBT_XREF_UPSTREAM_ENV', '')) -%}
+
+{%- if upstream_env == '' -%}
+    {#- Redirect not enabled for this run: behave exactly like ref() -#}
+    {{ return(rel) }}
+{%- endif -%}
+
+{%- set env_map = var('xref_env_map', {}) -%}
+{%- set env_cfg = env_map.get(upstream_env, {}) -%}
+{%- set new_database = env_cfg.get('database', rel.database) -%}
+{%- set new_schema = env_cfg.get('schema', rel.schema) -%}
+
+{%- set exposed_models = var('xref_exposed_models', {}) -%}
+{%- set exposed_key = package_name ~ '.' ~ model_name -%}
+{%- set new_identifier = exposed_models.get(exposed_key, rel.identifier) -%}
+
+{%- set new_rel = rel.replace_path(database=new_database, schema=new_schema, identifier=new_identifier) -%}
+
+{%- if execute -%}
+    {{ log("xref(): " ~ package_name ~ "." ~ model_name ~ " -> " ~ new_rel, info=true) }}
+{%- endif -%}
+
+{{ return(new_rel) }}
+
+{% endmacro %}

--- a/dbt_snowflake_downstream/macros/xref.sql
+++ b/dbt_snowflake_downstream/macros/xref.sql
@@ -68,6 +68,14 @@
           xref_exposed_models:
             secret.orders: vw_orders_prod_exposed
 
+    Logging: when xref_upstream_env is set, this always logs one line so a
+    redirect (or the lack of one) is visible in `dbt run`/`dbt compile`
+    output — but it distinguishes an actual redirect from a no-op. If
+    xref_upstream_env is set but xref_env_map has no entry for that env and
+    xref_exposed_models has no entry for this model, the resolved relation is
+    identical to plain ref() and the log says so explicitly, rather than
+    implying a redirect happened when it didn't.
+
     Usage: identical to ref() — {{ xref('secret', 'orders') }} or
     {{ xref('my_model') }} for a same-project ref.
 -#}
@@ -102,8 +110,19 @@
 
 {%- set new_rel = rel.replace_path(database=new_database, schema=new_schema, identifier=new_identifier) -%}
 
+{%- set redirected = (new_database != rel.database) or (new_schema != rel.schema) or (new_identifier != rel.identifier) -%}
+
 {%- if execute -%}
-    {{ log("xref(): " ~ package_name ~ "." ~ model_name ~ " -> " ~ new_rel, info=true) }}
+    {%- if redirected -%}
+        {{ log("xref(): redirected " ~ package_name ~ "." ~ model_name ~ " -> " ~ new_rel, info=true) }}
+    {%- else -%}
+        {{ log(
+            "xref(): xref_upstream_env='" ~ upstream_env ~ "' is set but no redirect was applied for "
+            ~ package_name ~ "." ~ model_name ~ " — no matching entry in xref_env_map['" ~ upstream_env
+            ~ "'] or xref_exposed_models['" ~ exposed_key ~ "']. Resolved relation unchanged: " ~ new_rel,
+            info=true
+        ) }}
+    {%- endif -%}
 {%- endif -%}
 
 {{ return(new_rel) }}

--- a/dbt_snowflake_downstream/macros/xref.sql
+++ b/dbt_snowflake_downstream/macros/xref.sql
@@ -3,14 +3,23 @@
     xref() — environment-aware cross-project ref for multi-pre-prod setups.
 
     Problem this solves (Macquarie demo):
-      dbt's native cross-project ref() always resolves an upstream PUBLIC model
-      to that upstream project's PRODUCTION relation, regardless of which
-      environment the downstream project is running in. Some orgs run several
-      long-lived pre-prod environments (dev/qa/uat/staging) that mirror each
-      other 1:1 upstream <-> downstream, and want staging-downstream to read
-      from staging-upstream, qa-downstream from qa-upstream, etc. — OR, as a
-      deliberate exception, want a specific non-prod environment (e.g. staging)
-      to read from the *prod* upstream because only prod has trustworthy data.
+      dbt's native cross-project ref() already resolves based on environment
+      type: a downstream PROD run reads the upstream project's PROD relation,
+      and any non-prod downstream run (dev, staging, etc.) reads the upstream
+      project's STAGING relation, if one is configured. Two gaps that leaves:
+        1. dbt Cloud only supports a single non-prod "staging" environment per
+           project. Orgs running several distinct long-lived pre-prod
+           environments (dev/qa/uat/staging) that are meant to mirror their
+           upstream counterparts 1:1 can't do so natively — every downstream
+           non-prod run collapses onto that one upstream staging environment
+           (or resolves to nothing, if upstream has no staging env configured).
+        2. Some orgs want the opposite override for a specific non-prod
+           environment: instead of reading upstream's staging (which may have
+           stale/untrustworthy data), a chosen non-prod env — e.g. staging —
+           should deliberately read the upstream *prod* relation.
+      xref() lets either case be handled explicitly, per environment, via
+      vars/env vars, without touching dbt's built-in ref() resolution logic
+      for everyone else.
 
     How it works:
       1. If called with a single arg, behaves exactly like ref(model_name) —
@@ -39,8 +48,8 @@
       xref_upstream_env:
         The upstream environment this run should read from, e.g. 'prod'.
         Leave unset (default '') to fall back to normal dbt Mesh behavior
-        (always prod, no rewrite) — this makes xref() a safe drop-in
-        replacement for ref() everywhere else.
+        (prod->prod, non-prod->upstream staging, no rewrite) — this makes
+        xref() a safe drop-in replacement for ref() everywhere else.
         Example: --vars '{"xref_upstream_env": "prod"}'
         or in dbt_project.yml under a target-specific block, or
         env_var('DBT_XREF_UPSTREAM_ENV').

--- a/dbt_snowflake_downstream/models/downstream_customers.sql
+++ b/dbt_snowflake_downstream/models/downstream_customers.sql
@@ -1,1 +1,1 @@
-select * from {{ ref('secret', 'customers') }}
+select * from {{ xref('secret', 'customers') }}

--- a/dbt_snowflake_downstream/models/downstream_orders.sql
+++ b/dbt_snowflake_downstream/models/downstream_orders.sql
@@ -1,1 +1,1 @@
-select * from {{ ref('secret', 'orders') }}
+select * from {{ xref('secret', 'orders') }}


### PR DESCRIPTION
Demo of the `xref()` pattern for Macquarie (multi pre-prod environments + cross-project refs).

**What's here:**
- `macros/xref.sql` — drop-in replacement for `ref()`. No-op unless `xref_upstream_env` is set (var or `DBT_XREF_UPSTREAM_ENV` env var), so it's safe to swap in everywhere.
- `macros/macros.yml` — doc entry for the macro.
- `models/downstream_customers.sql`, `models/downstream_orders.sql` — swapped from `ref('secret', ...)` to `xref('secret', ...)` to exercise it.

**Why this is needed:** native cross-project `ref()` already resolves prod downstream → prod upstream, and non-prod downstream → upstream's staging environment (if configured). The gaps: dbt Cloud only supports one non-prod staging environment per project, so multiple distinct pre-prod environments (dev/qa/uat) downstream can't each map to their own matching upstream counterpart; and some orgs want a specific non-prod environment to deliberately override and read upstream *prod* instead of upstream staging.

**Maps to Macquarie's two asks:**
1. Staging-downstream reading prod-upstream: set `xref_upstream_env: prod` + `xref_env_map` (database/schema per env) on the staging job/environment only.
2. Prod-view-vs-prod-table distinction: `xref_exposed_models` maps `package.model` → the identifier of the view variant, so either a tag or naming-prefix convention on the upstream side can drive it.

See PR conversation / attached demo notes for validation steps.